### PR TITLE
Запуск сsscomb для sublime в скрытом окне (win-only)

### DIFF
--- a/src/plugins/csscomb.sublime_text_2/csscomb/basesort.py
+++ b/src/plugins/csscomb.sublime_text_2/csscomb/basesort.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 import threading
-import sys,subprocess
+import sys,subprocess,os
 from os import path
 
 __file__ = path.normpath(path.abspath(__file__))
@@ -19,7 +19,13 @@ class BaseSort(threading.Thread):
         threading.Thread.__init__(self)
 
     def exec_request(self):
-        myprocess = subprocess.Popen(['php',csscomb_path,self.original], shell=False, stdout=subprocess.PIPE)
+        startupinfo = None
+        if os.name == 'nt':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = subprocess.SW_HIDE
+        
+        myprocess = subprocess.Popen(['php', csscomb_path, self.original], shell=False, stdout=subprocess.PIPE, startupinfo=startupinfo)
         (sout,serr) = myprocess.communicate()
         myprocess.wait()
 


### PR DESCRIPTION
Скрываем консоль в которой запускается csscomb. Насколько знаю, так можно сделать только под windows.
