### PR TITLE
This fixes issue #98

### DIFF
--- a/src/csscomb.php
+++ b/src/csscomb.php
@@ -1249,7 +1249,7 @@ class csscomb{
         foreach ($prop as $k => $val) {
             $index = null; // Дефолтное значение индекса порядка для свойства. Если свойство не знакомо, то index так и останется null.
             preg_match_all('@\s*?(.*?[^:]:).*@ism', $val, $matches, PREG_SET_ORDER);
-            $property = trim($matches[0][1]);
+            $property = preg_replace('/\s+/', '', trim($matches[0][1]));
 
             if (is_array($this->sort_order[0])) { // Если порядок сортировки разбит на группы свойств
 


### PR DESCRIPTION
This was fixed by removing all whitespace between the property name and the colon, hopefully not destroying anything else - unfortunately there are no instructions on how to run the tests :(
