### PR TITLE
Add Composer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/plugins/csscomb.webstorm_pycharm_idea/csscomb.php
 src/plugins/csscomb_for_coda_2.codaplugin/Contents/Resources/55543892-82DE-4679-9ADE-11CA109E2C68/Support\ Files/csscomb.php
 yuicompressor*
 build/*.zip
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "miripiruni/csscomb",
+    "description": "The greatest tool for sorting CSS properties in specific order.",
+    "homepage": "http://csscomb.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Slava Oliyanchuk",
+            "homepage": "http://miripiruni.org"
+        }
+    ],
+    "autoload": {
+        "classmap": ["src/csscomb.php"]
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a package management system for PHP. It allows consuming different PHP projects as dependencies into your project. Having a _composer.json_ in CSScomb would allow projects to bring CSScomb in as a development dependency and run CSScomb on their CSS files before deploying their project.
