### PR TITLE
Allows a single file to run and output by default in overwrite mode.

### DIFF
--- a/build/cli/csscomb.php
+++ b/build/cli/csscomb.php
@@ -1714,15 +1714,21 @@ function tool($argc, $argv){
                     file_put_contents($file, $result);
                 }
             }
-            elseif($this->out != null){
+            elseif(is_file($this->in) && preg_match('/^text/', mime_content_type($this->in))){
                 echo "Sorting ".$this->in."...\n";
-                if (preg_match('/^text/', mime_content_type($this->in))) {
-                    $result = $c->csscomb(file_get_contents($this->in));
-                    file_put_contents($this->out, $result);
-                } else {
-                    echo("Wrong input file mime type.");
-                    exit(1);
+                $result = $c->csscomb(file_get_contents($this->in));
+                if($this->out == null){
+                    $this->out = $this->in;
                 }
+                file_put_contents($this->out, $result);
+            }
+            elseif(!preg_match('/^text/', mime_content_type($this->in))){
+                echo("Wrong input file mime type.");
+                exit(1);
+            }
+            else{
+                echo("Error with input file.");
+                exit(1);
             }
             echo "Done.\n";
             exit(0);

--- a/src/cli.php
+++ b/src/cli.php
@@ -95,15 +95,21 @@ function tool($argc, $argv){
                     file_put_contents($file, $result);
                 }
             }
-            elseif($this->out != null){
+            elseif(is_file($this->in) && preg_match('/^text/', mime_content_type($this->in))){
                 echo "Sorting ".$this->in."...\n";
-                if (preg_match('/^text/', mime_content_type($this->in))) {
-                    $result = $c->csscomb(file_get_contents($this->in));
-                    file_put_contents($this->out, $result);
-                } else {
-                    echo("Wrong input file mime type.");
-                    exit(1);
+                $result = $c->csscomb(file_get_contents($this->in));
+                if($this->out == null){
+                    $this->out = $this->in;
                 }
+                file_put_contents($this->out, $result);
+            }
+            elseif(!preg_match('/^text/', mime_content_type($this->in))){
+                echo("Wrong input file mime type.");
+                exit(1);
+            }
+            else{
+                echo("Error with input file.");
+                exit(1);
             }
             echo "Done.\n";
             exit(0);


### PR DESCRIPTION
The cli instructions imply that this works, however the tool function was missing the code for it.

Also I added a final else to make sure that an error is thrown if something goes wrong and none of the other if/ifelse catch.

If you try to run just a single file on the cli:

php csscomb.php -i any_css_file.css

The cli tool reports done, however nothing happens.

Expected Behavior:

any_css_file.css is overwritten with the sorted version.
