### PR TITLE
Fix #192: Remove first character wisely

### DIFF
--- a/src/csscomb.php
+++ b/src/csscomb.php
@@ -1100,7 +1100,7 @@ class csscomb{
                 $this->code['resorted'] = substr($this->code['resorted'], 1);
             }
             // Remove all new lines if css initially didn't have any
-            if (substr_count($this->code['edited'], "\n") == 1) {
+            if (substr_count($this->code['edited'], "\n") === 1) {
                 $this->code['resorted'] = str_replace("\n", '', $this->code['resorted']);
             }
         }

--- a/src/csscomb.php
+++ b/src/csscomb.php
@@ -1095,7 +1095,14 @@ class csscomb{
         if ($this->mode === 'properties') {
             $this->code['edited'] = "\n".$this->code['edited'];
             $this->code['resorted'] = $this->parse_child($this->code['edited']);
-            $this->code['resorted'] = substr($this->code['resorted'], 1);
+            // Remove first line if it's empty
+            if (strpos($this->code['resorted'], "\n") === 0) {
+                $this->code['resorted'] = substr($this->code['resorted'], 1);
+            }
+            // Remove all new lines if css initially didn't have any
+            if (substr_count($this->code['edited'], "\n") == 1) {
+                $this->code['resorted'] = str_replace("\n", '', $this->code['resorted']);
+            }
         }
     }
 
@@ -1210,14 +1217,14 @@ class csscomb{
         @ismx', $value, $properties);
       // Удаляем их из общей строки
       foreach ($properties[0] as &$property) {
-        $value = str_replace($property, '', $value);  
+        $value = str_replace($property, '', $value);
       }
       // Сортируем свойства
       $props = $properties[0];
       $props = $this->resort_properties($props);
 
       // 5. Если осталось ещё что-то, оставляем «как есть»
-      
+
       // 6. Склеиваем всё обратно в следующем порядке:
       //   переменные, включения, простые свойства, вложенные {}
       $value = implode('', $vars[0]).implode('', $first_imports[0]).implode('', $imports[1]).implode('', $imports[2]).implode('', $block_imports).implode('', $props).$nested_string.$value;

--- a/www/tests/cases.php
+++ b/www/tests/cases.php
@@ -4134,6 +4134,15 @@ text-indent:-1234px;';
 $group['cases'][] = $case;
 
 
+
+$case['descr'] = 'Properties: single line';
+$case['descr-en'] = 'Properties: single line';
+$case['link'] = 'properties-single-line';
+$case['code'] = 'color:#999;font-size:.9em;border-top:1px solid #ddd;width:150px;';
+$case['result'] = 'width:150px;border-top:1px solid #ddd;color:#999;font-size:.9em;';
+$group['cases'][] = $case;
+
+
 $case['descr'] = 'HTML содержащий аттрибут style';
 $case['descr-en'] = 'Style attribute';
 $case['link'] = 'environment-style-attribute';


### PR DESCRIPTION
When sorting properties, remove first character only if it's a new line.
Also, if css was initially one string without any new lines, remove all `\n` characters.
